### PR TITLE
chore: bump version to 0.2.2 and fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Build
         working-directory: packages/typemap
-        run: uv build --no-sources
+        run: uv build
 
       - name: Publish to PyPI
         working-directory: packages/typemap

--- a/packages/typemap/.gitignore
+++ b/packages/typemap/.gitignore
@@ -15,3 +15,4 @@ venv/
 
 # uv
 .uv/
+dist/

--- a/packages/typemap/pyproject.toml
+++ b/packages/typemap/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "typemap"
-version = "0.2.0"
+version = "0.2.2"
 description = "PEP 827 type manipulation library"
 requires-python = ">=3.14"
 dependencies = [


### PR DESCRIPTION
Bump version and fix release workflow for PyPI publishing